### PR TITLE
Do not skip elements with children while iterating editor DOM

### DIFF
--- a/lib/conceal.coffee
+++ b/lib/conceal.coffee
@@ -9,6 +9,9 @@ module.exports =
 
   activate: ->
     replacements = atom.config.get 'conceal.replacements'
+    atom.config.observe 'conceal.replacements', (newValue) ->
+      replacements = newValue
+
     atom.workspace.observeTextEditors (editor) ->
       editor.onDidStopChanging ->
         view = atom.views.getView editor

--- a/lib/conceal.coffee
+++ b/lib/conceal.coffee
@@ -14,9 +14,7 @@ module.exports =
         view = atom.views.getView editor
         return unless view
 
-        for element in view.querySelectorAll '::shadow .line span'
-          continue unless element.childElementCount == 0
-
+        for element in view.querySelectorAll '::shadow .line span:not(.concealed)'
           replacement = replacements[element.textContent]
           continue unless replacement
 

--- a/styles/conceal.less
+++ b/styles/conceal.less
@@ -2,13 +2,15 @@ atom-text-editor::shadow {
   .line:not(.cursor-line) {
     .concealed {
       display: inline-block;
+      position: relative;
       visibility: hidden;
 
       &:before {
         content: attr(data-replacement);
-        display: inline-block;
+        position: absolute;
         visibility: visible;
-        width: 0;
+        text-align: center;
+        min-width: 100%;
       }
     }
   }


### PR DESCRIPTION
It would be nice to support concealing LaTeX symbols in Atom. However, the [language-latex](https://github.com/area/language-latex) package creates nested spans for something like `\alpha` (`<span><span\</span>alpha</span>`), which is not yet supported. This pull request removes `childElementCount == 0` for that reason.

Other changes:
- Observe configuration changes and update on change.
- Center the text in the overlay
