### PR TITLE
Reduce empty space

### DIFF
--- a/lib/conceal.coffee
+++ b/lib/conceal.coffee
@@ -6,6 +6,13 @@ module.exports =
         '::': '∷'
         '=>': '⇒'
         '->': '→'
+    preserveWidth:
+      type: 'boolean'
+      default: yes
+      title: 'Preserve the width of the concealed element'
+      description: 'When replacing an element you have the choice of replacing
+                    the entire value (including it\'s space) or preseve the
+                    width of the original element.'
 
   activate: ->
     replacements = atom.config.get 'conceal.replacements'
@@ -23,3 +30,5 @@ module.exports =
 
           element.classList.add 'concealed'
           element.dataset.replacement = replacement
+          unless atom.config.get 'conceal.preserveWidth'
+            element.dataset.replacementLength = replacement.length

--- a/styles/conceal.less
+++ b/styles/conceal.less
@@ -5,13 +5,22 @@ atom-text-editor::shadow {
       position: relative;
       visibility: hidden;
 
-      &:before {
+      &::before {
         content: attr(data-replacement);
         position: absolute;
         visibility: visible;
         text-align: center;
         min-width: 100%;
       }
+
+      .length-loop(@counter) when (@counter > 0) {
+        .length-loop((@counter - 1));
+        &[data-replacement-length="@{counter}"] {
+          width: @counter + 0em;
+        }
+      }
+
+      .length-loop(10);
     }
   }
 }


### PR DESCRIPTION
I'd like to try and reduce the empty space created by this plugin. The most ideal way would be to use the character length dynamically in CSS... however...

https://developer.mozilla.org/en/docs/Web/CSS/attr

> The attr() function can be used with any CSS property, **but support for properties other than content is experimental**.

:unamused: So, until we're able to use the `attr` function for widths, I've come up with this, I dare to say, slighty hacky approach. _Assuming_ that the replacement isn't going to be more than 10 characters in length, I've created a specific style for each situation. A bit yucky, but probably not much choice without using a ton of JavaScript.

![conceal](https://cloud.githubusercontent.com/assets/1423566/14205937/3249c1fe-f807-11e5-94b1-fc4ebff1d76c.gif)
