### PR TITLE
Remove default replacements

### DIFF
--- a/lib/conceal.coffee
+++ b/lib/conceal.coffee
@@ -2,10 +2,6 @@ module.exports =
   config:
     replacements:
       type: 'object'
-      default:
-        '::': '∷'
-        '=>': '⇒'
-        '->': '→'
     preserveWidth:
       type: 'boolean'
       default: yes


### PR DESCRIPTION
These get merged with the user's config, and they might not like the
default replacements (especially if you're running a font with
ligatures).